### PR TITLE
Add support for golangci-lint

### DIFF
--- a/include/lint.vim
+++ b/include/lint.vim
@@ -19,7 +19,7 @@ endif
 let g:ale_go_langserver_executable = 'gopls'
 
 let g:ale_linters = {
-\   'go': ['go build', 'gofmt', 'gometalinter', 'gopls'],
+\   'go': ['go build', 'gofmt', 'gometalinter', 'gopls', 'golangci-lint'],
 \   'typescript': ['tsserver', 'typecheck'],
 \   'javascript': ['eslint'],
 \   'ruby': ['rubocop', 'ruby'],


### PR DESCRIPTION
This linter seems to catch more potential errors than the standard
`golint`. For example, if you ignore the return value of a function, it
will report an error, whereas `golint` does not.

https://github.com/golangci/golangci-lint