### PR TITLE
Make coc-snippets use snippets defined in vim-go

### DIFF
--- a/coc-settings.json
+++ b/coc-settings.json
@@ -15,5 +15,9 @@
   "solargraph.completion": true,
   "solargraph.useBundler": true,
   "solargraph.rename": true,
-  "yaml.validate": false
+  "yaml.validate": false,
+  "snippets.ultisnips.directories": [
+    "UltiSnips",
+    "gosnippets/UltiSnips"
+  ]
 }


### PR DESCRIPTION
Following the advice [here](https://github.com/neoclide/coc-snippets#faq) we decided it will be good to expand the snippets vocabulary.