### PR TITLE
Introduce useful defaults for listmode/visible whitespace

### DIFF
--- a/include/basic.vim
+++ b/include/basic.vim
@@ -42,6 +42,10 @@ set shiftwidth=2          " Use indents of 2 spaces
 set softtabstop=2         " Let backspace delete indent
 set tabstop=2             " An indentation every four columns
 
+" Visible Whitespace
+set listchars=trail:·,precedes:«,extends:»,eol:↲,tab:▸\
+set nolist
+
 set undofile              " Persistent undo
 set undolevels=1000       " Maximum number of changes that can be undone
 set undoreload=10000      " Maximum number lines to save for undo on a buffer reload


### PR DESCRIPTION
With these changes, a user may `set list` to make their whitespace
visible. I would probably leave this on by default for myself but I can
understand it being distracting for others.

![image](https://user-images.githubusercontent.com/1565303/70484587-29b4e800-1aa1-11ea-8637-6cad727cc1b5.png)

Again this isn't on by default tho