### PR TITLE
Add option to sync OS clipboard and vi buffer

### DIFF
--- a/include/basic.vim
+++ b/include/basic.vim
@@ -78,6 +78,9 @@ set foldlevelstart=99
 autocmd InsertLeave,WinEnter * set cursorline
 autocmd InsertEnter,WinLeave * set nocursorline
 
+" OS Clipboard Synchronization
+set clipboard+=unnamedplus
+
 " netrw
 let g:netrw_altfile = 1   " <Ctrl-^> should go to the last file, not to netrw.
 


### PR DESCRIPTION
Yanking now copies also into OS Clipboard. 
Also OS Clipboard can now be pasted within visual mode.

This works well together with tmux mouse mode copy which works simmilarly and does not conflict:
```
# Copy to clipboard on selection
bind-key -T copy-mode MouseDragEnd1Pane send -X copy-pipe-and-cancel "pbcopy"
```

I only tested this on OSX. Should also work for Linux(nvim part, not the tmux part).