### PR TITLE
Add NERDTree plugin and shortcut to toggle

### DIFF
--- a/keyboard.vim
+++ b/keyboard.vim
@@ -76,6 +76,9 @@ nnoremap <Esc><Esc> :<C-u>nohlsearch<CR>
 
 let g:lmap =  {}
 
+" Open NERDTree on \
+nmap \ :NERDTreeToggle<CR>
+
 " Disable plugin mappings
 let g:swoopUseDefaultKeyMap = 0
 let g:gitgutter_map_keys = 1

--- a/plug.vim
+++ b/plug.vim
@@ -82,6 +82,10 @@ Plug 'tommcdo/vim-exchange'
 " }
 
 " General -- Helpful generic tools with no dependencies {
+
+" Nerdtree file explorer
+Plug 'scrooloose/nerdtree'
+
 " project configuration via 'projections'
 Plug 'tpope/vim-projectionist'
 


### PR DESCRIPTION
Adding NERDTree file explorer plugin. Setting the `\` key as default to toggle the tree view.

Many thanks

James & Gareth