### PR TITLE
Add a help file for migrating from legacy-vimfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ from the original [vim](https://www.vim.org) and focus on supporting
 [Neovim](https://neovim.io).  Neovim is a faster moving project that is much
 more approachable for contributions.
 
+If you're familiar with [luan/vimfiles](https://github.com/luan/vimfiles) and
+want to know what has noticeably changed, try `:help vimfiles-migrating` (or
+just `:help migrating`). You can view that help file online
+[here](https://github.com/luan/nvim/blob/master/doc/migrating-from-legacy.txt).
+
 ## ALPHA disclaimer
 
 This is currently an experiment to discover more efficient key mappings that

--- a/doc/migrating-from-legacy.txt
+++ b/doc/migrating-from-legacy.txt
@@ -1,0 +1,30 @@
+*migrating-from-legacy.txt*   Migrating from legacy-vimfiles
+
+==============================================================================
+MIGRATING FROM LEGACY VIMFILE                             *vimfiles-migrating*
+                                                                   *migrating*
+
+If you're used to the legacy-vimfiles, there are a few things in this vim
+config which may be unfamiliar. Here are the key differences, and why.
+
+-----------------------------------------------------------------------------
+QUICK DIFFERENCES
+
+- Leader has changed from `,` to `<Space>`
+- `:nohl` is no longer bound to `<Space>`. It's now `<Esc><Esc>`
+- NERDTree on `\` is deprecated in favour of |vinegar| and |netrw| on `-`
+  - For a NERDTree-like tree-view in |netrw|, hit `iii`
+- Running tests was `,t`. Now try `<Space>tf`
+
+-----------------------------------------------------------------------------
+PHILOSOPHY
+
+This config (currently available at https://github.com/luan/nvim) is intended
+to be a bit more "pure" than legacy-vimfiles (currently available at
+https://github.com/luan/vimfiles).
+The idea is to not override defaults unless absolutely
+necessary. This should make it easier to migrate back and forth between this
+config, other vim configs, and vanilla vim/vi.  For this reason, features
+added are exclusively additive to the standard Vim experience.
+
+vim:tw=78:ts=8:ft=help:norl:

--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,3 @@
+migrating	migrating-from-legacy.txt	/*migrating*
+migrating-from-legacy.txt	migrating-from-legacy.txt	/*migrating-from-legacy.txt*
+vimfiles-migrating	migrating-from-legacy.txt	/*vimfiles-migrating*


### PR DESCRIPTION
As [discussed here](https://github.com/luan/nvim/pull/25#issuecomment-579352864), this is a first stab at a help file for folks who want to know what's changed as they move from [legacy-vimfiles](https://github.com/luan/vimfiles) to this config.

There's a broken link in `README.md` in this PR, which I hope will un-break itself if the PR is merged.