### PR TITLE
Fix starscope call

### DIFF
--- a/keyboard.vim
+++ b/keyboard.vim
@@ -132,7 +132,7 @@ let g:leader_key_map.c = {
       \ 'a': ['cs find a <cword>', 'Cscope Assignments'],
       \ 'o': ['cs add cscope.out', 'Cscope Open Database'],
       \
-      \ 'z': ['!sh -xc ''starscope -e cscope -e ctags -x "*.go" -x "*.js"''', 'Cscope Build Database'],
+      \ 'z': [':!sh -xc starscope -e cscope -e ctags', 'Cscope Build Database'],
       \ }
 
 


### PR DESCRIPTION
It was giving an error whenever I tried to use it; this fixes that
error. It also no longer skips go/js files so it can be used for go and
js projects as well.