### PR TITLE
Add SyntaxGroup helper command

### DIFF
--- a/include/syntax.vim
+++ b/include/syntax.vim
@@ -1,0 +1,7 @@
+fun! GetSyntaxGroup()
+  let l:s = synID(line('.'), col('.'), 1)
+  echo synIDattr(l:s, 'name') . ' -> ' . synIDattr(synIDtrans(l:s), 'name')
+endfun
+
+" SyntaxGroup: print the syntax highlight group of the element under the cursor
+command! SyntaxGroup call GetSyntaxGroup()


### PR DESCRIPTION
This command is useful when creating new color schemes. Running `:SyntaxGroup` will display the syntax highlighting group of the text element under the cursor, which can then be targeted and styled from a color scheme.