### PR TITLE
Update coc-solargraph config to do more things

### DIFF
--- a/coc-settings.json
+++ b/coc-settings.json
@@ -18,6 +18,9 @@
   "solargraph.hover": true,
   "solargraph.rename": true,
   "solargraph.useBundler": true,
+  "solargraph.symbols": true,
+  "solargraph.definitions": true,
+  "solargraph.references": true,
   "suggest.enablePreselect": false,
   "yaml.validate": false,
   "go.goplsOptions": {


### PR DESCRIPTION
This enables actual code navigation stuff like go-to definition, find references, and symbol searching for ruby projects.

This would be very helpful pls. Idk if we have to configure other things too though? Like that `include/coc.vim` file? Tested that all the above features worked with this change only
