### PR TITLE
remove textwidth limitation

### DIFF
--- a/include/basic.vim
+++ b/include/basic.vim
@@ -21,7 +21,7 @@ set ttimeoutlen=0         " Timeout for completing commands
 set cscopequickfix=s-,c-,d-,i-,t-,e-,a-,g- "
 set inccommand=nosplit    " Preview commands like substitute
 set nomodeline            " Older versions of neovim might have this security issue: https://github.com/numirias/security/blob/master/doc/2019-06-04_ace-vim-neovim.md
-set textwidth=100         " Limit text width to 100
+set textwidth=0           " Unlimited text width
 
 set ignorecase            " Case insensitive search
 set smartcase             " ... but case sensitive when uc present

--- a/include/basic.vim
+++ b/include/basic.vim
@@ -21,7 +21,6 @@ set ttimeoutlen=0         " Timeout for completing commands
 set cscopequickfix=s-,c-,d-,i-,t-,e-,a-,g- "
 set inccommand=nosplit    " Preview commands like substitute
 set nomodeline            " Older versions of neovim might have this security issue: https://github.com/numirias/security/blob/master/doc/2019-06-04_ace-vim-neovim.md
-set textwidth=0           " Unlimited text width
 
 set ignorecase            " Case insensitive search
 set smartcase             " ... but case sensitive when uc present


### PR DESCRIPTION
resolves #39

This was adding newlines to many files where they shouldn't be, breaking certain kinds of bash scripts. Enforcing line length should be the responsibility of a language-specific linter, not a global rule for the editor.