### PR TITLE
Add syntax highlighting for ytt

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -261,7 +261,7 @@ Plug 'rust-lang/rust.vim', { 'for': 'rust' }
 " ytt/Starlark {
 Plug 'cappyzawa/starlark.vim'
 Plug 'cappyzawa/ytt.vim'
-"
+" }
 
 " Org Mode {
 Plug 'jceb/vim-orgmode'

--- a/plug.vim
+++ b/plug.vim
@@ -258,6 +258,11 @@ Plug 'elmcast/elm-vim', { 'for': 'elm' }
 Plug 'rust-lang/rust.vim', { 'for': 'rust' }
 " }
 
+" ytt/Starlark {
+Plug 'cappyzawa/starlark.vim'
+Plug 'cappyzawa/ytt.vim'
+"
+
 " Org Mode {
 Plug 'jceb/vim-orgmode'
 " }


### PR DESCRIPTION
With these plugins, ytt support is not enabled by default. It can be toggled with `:EnableYtt` and `:DisableYtt` in YAML files.

But let me know if you don't want this; you may not be ytt'ing much these days.

Thanks!! Hope you're doing well @luan! @belinda-liu says hi!