### PR TITLE
Restores fzf.vim

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -277,6 +277,8 @@ Plug 'kurayama/systemd-vim-syntax'
 Plug 'peterhoeg/vim-qml'
 Plug 'uarun/vim-protobuf'
 Plug 'junegunn/vader.vim'
+Plug 'junegunn/fzf', { 'do': { -> fzf#install() } }
+Plug 'junegunn/fzf.vim'
 " }
 " }
 


### PR DESCRIPTION
I rely on fzf.vim commands like :Maps, :BLines, and other such commands
to easily search for mappings or populate the quickfix list in my
current buffer, for example.