### PR TITLE
Use coc for Clap tags executive [1]

### DIFF
--- a/keyboard.vim
+++ b/keyboard.vim
@@ -119,7 +119,7 @@ let g:leader_key_map.s = {
       \ 'name': '+search',
       \ 'g': ['Grepper',            'Find in directory (quickfix)'],
       \ 'f': [':Clap grep ',        'Find in directory (live)'],
-      \ 't': [':Clap tags',         'Find tags'],
+      \ 't': [':Clap tags coc',     'Find tags'],
       \ 'l': [':Clap lines',        'Find lines in open files'],
       \ 'b': [':Clap blines',       'Find lines in current buffer'],
       \ 'p': ['<Plug>CtrlSFPrompt', 'Find in directory (ctrlsf)'],


### PR DESCRIPTION
Assuming that coc is working, it seems like it's a more reliable source
than to rely on Universal Ctags (the default).

[1]: https://github.com/liuchengxu/vim-clap/blob/695363e4310252fba8139970e16b76045f14781c/doc/clap-support.txt#L159