### PR TITLE
Update jsx plugin

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -229,7 +229,7 @@ Plug 'othree/yajs.vim'
 Plug 'othree/es.next.syntax.vim'
 Plug 'othree/javascript-libraries-syntax.vim'
 Plug 'ternjs/tern_for_vim', {'do': 'npm install'}
-Plug 'mxw/vim-jsx'
+Plug 'maxmellon/vim-jsx-pretty'
 " }
 
 " TypeScript {


### PR DESCRIPTION
The README on https://github.com/mxw/vim-jsx mentions that it is deprecated 
and points to https://github.com/MaxMEllon/vim-jsx-pretty as a proposed alternative.