### PR TITLE
Check for fdfind as well if fd is not present

### DIFF
--- a/update.vim
+++ b/update.vim
@@ -7,7 +7,13 @@ function! s:checkDependencies()
 
   for l:dep in l:dependencies
     if !executable(l:dep)
-      call add(s:missing, l:dep)
+      if l:dep != 'fd'
+        call add(s:missing, l:dep)
+      else
+         if !executable('fdfind')
+            call add(s:missing, 'fd')
+         endif
+      endif
     endif
   endfor
 


### PR DESCRIPTION
On Ubuntu fd-find's binary has been renamed from [fd` to `fdfind ](https://github.com/sharkdp/fd#on-ubuntu)leading to me and @sethboyles always seeing a dependency warning when we launch nvim, we made this change to not post the missing dependency warning as it will check for fdfind if fd is not present.  We checked Vim-Clap using :Clap after talking to [Luan in cloudfoundry slack](https://cloudfoundry.slack.com/archives/C0YVC7K8S/p1612994834175500) and saw it working with our change just fine.

Let us know if you have any questions :D!

Thanks!
Jenna and Seth