### PR TITLE
Fix organizeImport

### DIFF
--- a/include/coc.vim
+++ b/include/coc.vim
@@ -25,7 +25,7 @@ command! -nargs=? Fold :call CocAction('fold', <f-args>)
 
 augroup config#go#coc
   autocmd!
-  autocmd BufWritePre *.go :CocCommand editor.action.organizeImport
+  autocmd BufWritePre *.go :silent call CocAction('runCommand', 'editor.action.organizeImport')
 augroup END
 
 let s:languageserver = {}


### PR DESCRIPTION
I was seeing some weird behavior where when I'd save a file and it added/changed imports that random parts of my Go file would get deleted/rearranged.

I don't know why this fixes it, but this is how it's recommended to do this [on the coc-go README](https://github.com/josa42/coc-go#examples)

![glitch](https://user-images.githubusercontent.com/239754/112009523-d7b09e00-8afc-11eb-8c9e-b70a68988cdd.gif)
