### PR TITLE
Replace deprectead coc-python with coc-pyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ order to properly setup everything:
   * [`bat`](https://github.com/sharkdp/bat):  A cat(1) clone with syntax
     highlighting and Git integration.
 
+**Python Dependencies**: To ensure smooth work for `coc-pyright` we must install
+the following dependencies via `pip` (`$ pip install isort black`):
+
+  * ['isort'](https://pypi.org/project/isort/): used to sort dependencies
+  * ['black'](https://github.com/psf/black): used to lint Python code
+
 Once you have that setup, all you have to do is clone this config in the right
 spot:
 

--- a/include/coc.vim
+++ b/include/coc.vim
@@ -5,7 +5,7 @@ let g:coc_global_extensions = [
       \   'coc-highlight',
       \   'coc-html',
       \   'coc-json',
-      \   'coc-python',
+      \   'coc-pyright',
       \   'coc-rust-analyzer',
       \   'coc-rls',
       \   'coc-snippets',
@@ -49,74 +49,6 @@ if executable('bash-language-server')
         \   "args": ["start"],
         \   "filetypes": ["sh"],
         \   "ignoredRootPaths": ["~"]
-        \ }
-endif
-
-if executable('python')
-  let s:languageserver["python"] = {
-        \   "command": "python",
-        \   "args": [
-        \     "-mpyls",
-        \     "-vv",
-        \     "--log-file",
-        \     "/tmp/lsp_python.log"
-        \   ],
-        \   "trace.server": "verbose",
-        \   "filetypes": ["python"],
-        \   "settings": {
-        \     "pyls": {
-        \       "enable": v:true,
-        \       "trace": {
-        \         "server": "verbose"
-        \       },
-        \       "commandPath": "",
-        \       "configurationSources": [
-        \         "pycodestyle"
-        \       ],
-        \       "plugins": {
-        \         "jedi_completion": {
-        \           "enabled": v:true
-        \         },
-        \         "jedi_hover": {
-        \           "enabled": v:true
-        \         },
-        \         "jedi_references": {
-        \           "enabled": v:true
-        \         },
-        \         "jedi_signature_help": {
-        \           "enabled": v:true
-        \         },
-        \         "jedi_symbols": {
-        \           "enabled": v:true,
-        \           "all_scopes": v:true
-        \         },
-        \         "mccabe": {
-        \           "enabled": v:true,
-        \           "threshold": 15
-        \         },
-        \         "preload": {
-        \           "enabled": v:true
-        \         },
-        \         "pycodestyle": {
-        \           "enabled": v:true
-        \         },
-        \         "pydocstyle": {
-        \           "enabled": v:false,
-        \           "match": "(?!test_).*\\.py",
-        \           "matchDir": "[^\\.].*"
-        \         },
-        \         "pyflakes": {
-        \           "enabled": v:true
-        \         },
-        \         "rope_completion": {
-        \           "enabled": v:true
-        \         },
-        \         "yapf": {
-        \           "enabled": v:true
-        \         }
-        \       }
-        \     }
-        \   }
         \ }
 endif
 


### PR DESCRIPTION
[coc-python](https://github.com/neoclide/coc-python) was deprectead long
time ago and most of the time it is not working on a modern Python
codebase. This commit replaces that Coc plugin with actively maintained
[coc-pyright](https://github.com/fannheyward/coc-pyright) which is based
on [pyright](https://github.com/microsoft/pyright), static type checker
from VS Code.