### PR TITLE
Ignore BUILD.bazel files in fuzzy find

### DIFF
--- a/include/fuzzy.vim
+++ b/include/fuzzy.vim
@@ -1,5 +1,5 @@
 if executable('fd')
-  let $FZF_DEFAULT_COMMAND = 'fd --exclude={.git,.idea,.vscode,.sass-cache,node_modules,build} --type f'
+  let $FZF_DEFAULT_COMMAND = 'fd --exclude={.git,.idea,.vscode,.sass-cache,node_modules,build,BUILD.bazel} --type f'
 elseif executable('rg')
   let $FZF_DEFAULT_COMMAND = 'rg --files --hidden --follow --glob "!.git/*" --glob "!node_modules/*"'
 elseif executable('ag')


### PR DESCRIPTION
Bazel based project are littered with these files and they **should** be managed through automation and tooling. So the likelihood anyone would want to match them is low at best.