### PR TITLE
Fix new Go autocmd

### DIFF
--- a/ftplugin/go.lua
+++ b/ftplugin/go.lua
@@ -18,9 +18,7 @@ function GoImportsSync(timeout_ms)
     end
 end
 
-vim.api.nvim_command([[
-augroup config#go
-    autocmd!
-    autocmd BufWritePre *.go lua GoImportsSync(1000)
-augroup END
-]])
+vim.api.nvim_command([[augroup config#go]])
+vim.api.nvim_command([[autocmd!]])
+vim.api.nvim_command([[autocmd BufWritePre *.go lua GoImportsSync(1000)]])
+vim.api.nvim_command([[augroup END]])


### PR DESCRIPTION
fixes #59

Not really sure why the lua multiline string doesn't work, but it doesn't 