### PR TITLE
Remove deprecated diagnostics source

### DIFF
--- a/lua/plugins/lualine.lua
+++ b/lua/plugins/lualine.lua
@@ -15,7 +15,7 @@ require('lualine').setup {
                 path = 1,
             },
         },
-        lualine_x = {{ 'diagnostics', sources = {'nvim_lsp'}}, 'encoding', 'fileformat'},
+        lualine_x = {{ 'diagnostics', sources = {'nvim_diagnostic'}}, 'encoding', 'fileformat'},
         lualine_y = {'progress'},
         lualine_z = {'location', require('update').status }
     },


### PR DESCRIPTION
- Diagnostics source `nvim_lsp` has been deprecated in favour of `nvim_diagnostic`.
nvim_diagnostic shows diagnostics from neovim's diagnostics api
while nvim_lsp used to only show lsp diagnostics.