### PR TITLE
Skip phpdoc in tree-sitter

### DIFF
--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -3,6 +3,7 @@ require('nvim-treesitter.configs').setup {
   highlight = {
     enable = true,              -- false will disable the whole extension
   },
+  ignore_install = { "phpdoc" },
   incremental_selection = {
     enable = true,
     keymaps = {


### PR DESCRIPTION
Why?
===
It fails to install on m1 macs.[1]

[1]: https://www.reddit.com/r/neovim/comments/pq1ype/treesitter_on_arm64/
