### PR TITLE
Revert "Allow enter key to accept completion"

### DIFF
--- a/lua/plugins/completion.lua
+++ b/lua/plugins/completion.lua
@@ -27,7 +27,6 @@ cmp.setup({
   },
   mapping = {
     ['<C-y>'] = cmp.mapping.confirm({ select = true }),
-    ['<Enter>'] = cmp.mapping.confirm({ select = true }),
 
     ['<Tab>'] = next,
     ['<C-n>'] = next,


### PR DESCRIPTION
This turns out to be really annoying, I'm typing stuff and hit enter expecting a carriage return and get some random completion inserted instead

Reverts luan/nvim#84