### PR TITLE
Disable gitsigns integration as it's no longer available

### DIFF
--- a/lua/plugins/truezen.lua
+++ b/lua/plugins/truezen.lua
@@ -38,7 +38,7 @@ true_zen.setup({
 	},
 	integrations = {
 		tmux = false,
-		gitsigns = true,
+		gitsigns = false,
 		limelight = false,
 		lualine = true,
 	},


### PR DESCRIPTION
This was causing a error message every time vim loads up, as it couldn't
find the gitsigns.nvim anymore - which was replaced by vgit.