### PR TITLE
Update cmp-nvim-lsp config for deprecation

### DIFF
--- a/lua/lang.lua
+++ b/lua/lang.lua
@@ -8,10 +8,7 @@ local lsp_format = require("lsp-format")
 
 lsp_format.setup()
 
-
-local capabilities = vim.lsp.protocol.make_client_capabilities()
-capabilities = require('cmp_nvim_lsp').update_capabilities(capabilities)
-capabilities.textDocument.completion.completionItem.snippetSupport = true
+local capabilities = require('cmp_nvim_lsp').default_capabilities()
 
 lsp_installer.setup {
   automatic_installation = true,


### PR DESCRIPTION
update_capabilities was deprecated, per this PR:
https://github.com/hrsh7th/cmp-nvim-lsp/pull/35/files

switched to default_capabilities()

Co-authored-by: Christian Ang <christian.ang@outlook.com>