### PR TITLE
Fix lir devicons deprecation warning

### DIFF
--- a/lua/plugins/lir.lua
+++ b/lua/plugins/lir.lua
@@ -4,7 +4,9 @@ local clipboard_actions = require 'lir.clipboard.actions'
 
 require('lir').setup {
   show_hidden_files = true,
-  devicons_enable = true,
+  devicons = {
+    enable = true,
+  },
   mappings = {
     ['<cr>']  = actions.edit,
     ['<C-s>'] = actions.split,


### PR DESCRIPTION
`devicons_enable` is deprecated and we should use `devicons.enable` instead.